### PR TITLE
Make api url configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sonar.auth.bitbucket.clientId.secured|Consumer Key provided by Bitbucket when re
 sonar.auth.bitbucket.clientSecret.secured|Consumer password provided by Bitbucket when registering the consumer|None
 sonar.auth.bitbucket.enabled|Enable Bitbucket users to login. Value is ignored if consumer Key and Secret are not defined|false
 sonar.auth.bitbucket.loginStrategy|When the login strategy is set to 'Unique', the user's login will be auto-generated the first time so that it is unique. When the login strategy is set to 'Same as Bitbucket login', the user's login will be the Bitbucket login. This last strategy allows, when changing the authentication provider, to keep existing users (if logins from new provider are the same than Bitbucket)|Unique
+sonar.auth.bitbucket.apiUrl|Allows configurable bitbucket api url for pointing it to your bitbucket server. This will allow users & credentials to be reused from configured bitbucket|https://api.bitbucket.org// 
 
 # Have question or feedback?
 To provide feedback (request a feature, report a bug etc.) use the [SonarQube Google Group](https://groups.google.com/forum/#!forum/sonarqube). Please do not forget to specify plugin and SonarQube versions if it relates to a bug.

--- a/src/main/java/org/sonarqube/auth/bitbucket/BitbucketSettings.java
+++ b/src/main/java/org/sonarqube/auth/bitbucket/BitbucketSettings.java
@@ -22,6 +22,7 @@ package org.sonarqube.auth.bitbucket;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
+
 import org.sonar.api.PropertyType;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.Settings;
@@ -37,9 +38,10 @@ public class BitbucketSettings {
   public static final String CONSUMER_SECRET = "sonar.auth.bitbucket.clientSecret.secured";
   public static final String ENABLED = "sonar.auth.bitbucket.enabled";
   public static final String ALLOW_USERS_TO_SIGN_UP = "sonar.auth.bitbucket.allowUsersToSignUp";
-  // URLs are not configurable yet
   public static final String API_URL = "sonar.auth.bitbucket.apiUrl";
   public static final String DEFAULT_API_URL = "https://api.bitbucket.org/";
+
+  // URLs are not configurable yet
   public static final String WEB_URL = "sonar.auth.bitbucket.webUrl";
   public static final String DEFAULT_WEB_URL = "https://bitbucket.org/";
   public static final String LOGIN_STRATEGY = "sonar.auth.bitbucket.loginStrategy";
@@ -133,7 +135,7 @@ public class BitbucketSettings {
         .subCategory(SUBCATEGORY)
         .type(PropertyType.BOOLEAN)
         .defaultValue(String.valueOf(true))
-        .index(4)
+        .index(index++)
         .build(),
       PropertyDefinition.builder(LOGIN_STRATEGY)
         .name("Login generation strategy")
@@ -146,7 +148,15 @@ public class BitbucketSettings {
         .defaultValue(LOGIN_STRATEGY_DEFAULT_VALUE)
         .options(LOGIN_STRATEGY_UNIQUE, LOGIN_STRATEGY_PROVIDER_LOGIN)
         .index(index++)
-        .build()
-      );
+        .build(),
+      PropertyDefinition.builder(API_URL)
+        .name("Bitbucket Api url")
+        .description("Configurable Bit bucket url.")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .defaultValue(DEFAULT_API_URL)
+        .index(index)
+        .build());
   }
+
 }

--- a/src/test/java/org/sonarqube/auth/bitbucket/AuthBitbucketPluginTest.java
+++ b/src/test/java/org/sonarqube/auth/bitbucket/AuthBitbucketPluginTest.java
@@ -29,7 +29,7 @@ public class AuthBitbucketPluginTest {
 
   @Test
   public void test_extensions() {
-    assertThat(underTest.getExtensions()).hasSize(9);
+    assertThat(underTest.getExtensions()).hasSize(10);
   }
 
 }

--- a/src/test/java/org/sonarqube/auth/bitbucket/BitbucketSettingsTest.java
+++ b/src/test/java/org/sonarqube/auth/bitbucket/BitbucketSettingsTest.java
@@ -99,6 +99,15 @@ public class BitbucketSettingsTest {
   }
 
   @Test
+  public void configure_api_Url() throws Exception {
+    final String configuredApiUrl = "https://test-company.api.bitbucket.org/";
+
+    settings.setProperty("sonar.auth.bitbucket.apiUrl", configuredApiUrl);
+
+    assertThat(underTest.apiURL()).isEqualTo(configuredApiUrl);
+  }
+
+  @Test
   public void default_apiUrl() {
     assertThat(underTest.apiURL()).isEqualTo("https://api.bitbucket.org/");
   }
@@ -110,7 +119,7 @@ public class BitbucketSettingsTest {
 
   @Test
   public void definitions() {
-    assertThat(BitbucketSettings.definitions()).hasSize(5);
+    assertThat(BitbucketSettings.definitions()).hasSize(6);
   }
 
 }


### PR DESCRIPTION
Hi,

This is Pradeep Semwal from Tingcore Fortum. We had a feature request by my colleague Sachin Gharge (@sachingharge) and had email exchange with Julien Lancelot. Our branch contains following changes

-We have fixed a small bug 
-Change for making sonar.auth.bitbucket.apiUrl configurable.